### PR TITLE
Update JdbcRDD.scala to remove hard-coded restriction on JDBC fetchSize

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/JdbcRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/JdbcRDD.scala
@@ -90,11 +90,12 @@ class JdbcRDD[T: ClassTag](
       // dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-implementation-notes.html
 
       stmt.setFetchSize(Integer.MIN_VALUE)
-    } else {
-      stmt.setFetchSize(100)
     }
+//     else {
+//       stmt.setFetchSize(100)
+//     }
 
-    logInfo(s"statement fetch size set to: ${stmt.getFetchSize}")
+    logInfo(s"Luke Skywalker's Jedi - statement fetch size set to: ${stmt.getFetchSize}")
 
     stmt.setLong(1, part.lower)
     stmt.setLong(2, part.upper)


### PR DESCRIPTION
Remove hard-coded restriction on JDBC fetchSize so user could change it when needed.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
